### PR TITLE
style: improved the lighting

### DIFF
--- a/examples/basic/src/main.ts
+++ b/examples/basic/src/main.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @masknet/no-top-level */
-import { initAmmo, MMDAnimationHelper, MMDLoader } from '@moeru/three-mmd'
+import { initAmmo, MMDAnimationHelper, MMDLoader, MMDToonMaterial } from '@moeru/three-mmd'
 import {
-  AmbientLight,
   Clock,
   Color,
   DirectionalLight,
+  DirectionalLightHelper,
   PerspectiveCamera,
   PolarGridHelper,
   Scene,
@@ -38,12 +38,22 @@ await initAmmo()
     gridHelper.position.y = -10
     scene.add(gridHelper)
 
-    const ambient = new AmbientLight(0xAAAAAA, 3)
-    scene.add(ambient)
+    // NOTICE: value tuned here for most of the MMD models
+    // made after or between 2021 to 2023, but it will be a bit dark
+    // for several models like the default Hatsune Miku, or way dark
+    // for known Miku V4C.
+    // const directionalLight = new DirectionalLight(0xFFFFFF, 2.85)
+    const directionalLight = new DirectionalLight(0xFFFFFF, 4.28)
 
-    const directionalLight = new DirectionalLight(0xFFFFFF, 3)
-    directionalLight.position.set(-1, 1, 1).normalize()
+    // WORKAROUND: since tracing against target wasn't correctly implemented
+    // here the directional light pos & rotation was set for targeting the center
+    // of the model.
+    directionalLight.position.set(2.1, 0, 24)
+    directionalLight.rotation.set(0, 2 * Math.PI, 0)
     scene.add(directionalLight)
+
+    const directionalLightHelper = new DirectionalLightHelper(directionalLight, undefined, 0x000000)
+    scene.add(directionalLightHelper)
 
     const renderer = new WebGLRenderer({ antialias: true })
     renderer.setPixelRatio(window.devicePixelRatio)
@@ -65,7 +75,25 @@ await initAmmo()
       (mmd) => {
         const mesh = mmd.mesh
         mesh.position.y = -10
+
+        if (Array.isArray(mesh.material)) {
+          for (const material of mesh.material) {
+            if (material instanceof MMDToonMaterial) {
+              // TODO: if colored texture with special emissive values
+              // then we should not really set this to default value of
+              // 0x000000 (e.g. if the model has a part emits color
+              // by it self, small battery supported light strips)
+              //
+              // https://github.com/mrdoob/three.js/issues/28336
+              material.emissive?.set(0x000000)
+            }
+          }
+        }
         scene.add(mesh)
+        // TODO: directional light should follow the target but currently
+        // it wasn't so we will just leave it as is right now but need
+        // to implement this feature later
+        // directionalLight.target = mesh
 
         helper.add(mesh, {
           animation: mmd.animation,
@@ -81,39 +109,103 @@ await initAmmo()
         scene.add(physicsHelper)
 
         const initGui = () => {
-          const api = {
-            'animation': true,
-            'ik': true,
-            'outline': true,
-            'physics': true,
-            'show IK bones': false,
-            'show rigid bodies': false,
-          }
-
           const gui = new GUI()
 
-          gui.add(api, 'animation').onChange(() => {
-            helper.enable('animation', api.animation)
+          const guiControls = gui.addFolder('Controls')
+          const lilStatesControls = {
+            'Animation': true,
+            'IK': true,
+            'Outline': true,
+            'Physics': true,
+            'Show IK bones': false,
+            'Show rigid bodies': false,
+          }
+
+          guiControls.add(lilStatesControls, 'Animation').onChange(() => {
+            helper.enable('Animation', lilStatesControls.Animation)
           })
 
-          gui.add(api, 'ik').onChange(() => {
-            helper.enable('ik', api.ik)
+          guiControls.add(lilStatesControls, 'IK').onChange(() => {
+            helper.enable('IK', lilStatesControls.IK)
           })
 
-          gui.add(api, 'outline').onChange(() => {
-            effect.enabled = api.outline
+          guiControls.add(lilStatesControls, 'Outline').onChange(() => {
+            effect.enabled = lilStatesControls.Outline
           })
 
-          gui.add(api, 'physics').onChange(() => {
-            helper.enable('physics', api.physics)
+          guiControls.add(lilStatesControls, 'Physics').onChange(() => {
+            helper.enable('physics', lilStatesControls.Physics)
           })
 
-          gui.add(api, 'show IK bones').onChange(() => {
-            ikHelper.visible = api['show IK bones']
+          guiControls.add(lilStatesControls, 'Show IK bones').onChange(() => {
+            ikHelper.visible = lilStatesControls['Show IK bones']
           })
 
-          gui.add(api, 'show rigid bodies').onChange(() => {
-            physicsHelper.visible = api['show rigid bodies']
+          guiControls.add(lilStatesControls, 'Show rigid bodies').onChange(() => {
+            physicsHelper.visible = lilStatesControls['Show rigid bodies']
+          })
+
+          const guiMesh = gui.addFolder('Mesh')
+          const lilStatesMesh = {
+            'Mesh X': mesh.position.x,
+            'Mesh Y': mesh.position.y,
+            'Mesh Z': mesh.position.z,
+          }
+
+          guiMesh.add(lilStatesMesh, 'Mesh X', -20, 20).onChange(() => {
+            mesh.position.x = lilStatesMesh['Mesh X']
+          })
+
+          guiMesh.add(lilStatesMesh, 'Mesh Y', -20, 20).onChange(() => {
+            mesh.position.y = lilStatesMesh['Mesh Y']
+          })
+
+          guiMesh.add(lilStatesMesh, 'Mesh Z', -20, 20).onChange(() => {
+            mesh.position.z = lilStatesMesh['Mesh Z']
+          })
+
+          const guiDirectionalLight = gui.addFolder('Directional light')
+          const lilStatesDirectionalLight = {
+            'Directional light color': directionalLight.color.getHex(),
+            'Directional light intensity': directionalLight.intensity,
+            'Directional light X': 2.1,
+            'Directional light Y': 0,
+            'Directional light Z': 24,
+            'Directional light rotate X': 0,
+            'Directional light rotate Y': 2 * Math.PI,
+            'Directional light rotate Z': 0,
+          }
+
+          guiDirectionalLight.addColor(lilStatesDirectionalLight, 'Directional light color').onChange(() => {
+            directionalLight.color.set(lilStatesDirectionalLight['Directional light color'])
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light intensity', 0, 20).onChange(() => {
+            directionalLight.intensity = lilStatesDirectionalLight['Directional light intensity']
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light X', -50, 50).onChange(() => {
+            directionalLight.position.x = lilStatesDirectionalLight['Directional light X']
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light Y', -50, 50).onChange(() => {
+            directionalLight.position.y = lilStatesDirectionalLight['Directional light Y']
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light Z', -50, 50).onChange(() => {
+            directionalLight.position.z = lilStatesDirectionalLight['Directional light Z']
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light rotate X', - 2* Math.PI, 2 * Math.PI).onChange(() => {
+            directionalLight.rotation.x = lilStatesDirectionalLight['Directional light rotate X']
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light rotate Y', - 2* Math.PI, 2 * Math.PI).onChange(() => {
+            directionalLight.rotation.y = lilStatesDirectionalLight['Directional light rotate Y']
+          })
+
+          guiDirectionalLight.add(lilStatesDirectionalLight, 'Directional light rotate Z', - 2* Math.PI, 2 * Math.PI).onChange(() => {
+            directionalLight.rotation.z = lilStatesDirectionalLight['Directional light rotate Z']
           })
         }
 

--- a/packages/three-mmd/src/index.ts
+++ b/packages/three-mmd/src/index.ts
@@ -1,6 +1,7 @@
 export { MMDAnimationHelper } from './animation/MMDAnimationHelper'
 export { MMDPhysics } from './animation/MMDPhysics'
 export { ExperimentalMMDLoader } from './loaders/mmd-loader'
+export { MMDToonMaterial } from './loaders/MMDLoader'
 export { MMDLoader } from './loaders/MMDLoader'
 export { PMDLoader } from './loaders/pmd-loader'
 export { PMXLoader } from './loaders/pmx-loader'

--- a/packages/three-mmd/src/loaders/MMDLoader.d.ts
+++ b/packages/three-mmd/src/loaders/MMDLoader.d.ts
@@ -1,5 +1,6 @@
 import type { Pmd, Pmx, Vmd } from '@noname0310/mmd-parser'
-import type { AnimationClip, Camera, FileLoader, Loader, LoadingManager, SkinnedMesh } from 'three'
+import type { AnimationClip, Camera, Color, FileLoader, Loader, LoadingManager, ShaderMaterial, SkinnedMesh } from 'three'
+import type { MMDToonMaterial } from '..'
 
 export interface MMDLoaderAnimationObject {
   animation: AnimationClip
@@ -74,4 +75,13 @@ export class MMDLoader extends Loader<SkinnedMesh> {
     onError?: (event: ErrorEvent) => void,
   ): void
   setAnimationPath(animationPath: string): this
+}
+
+export class MMDToonMaterial extends ShaderMaterial {
+  // TODO: emissive declared in MaterialJSON but not where can be
+  // found under ShaderMaterial nor Material, but mentioned as
+  // https://github.com/mrdoob/three.js/issues/28336, setting
+  // emissive for colored textures was required.
+  emissive?: Color
+  emissiveIntensity?: number
 }

--- a/packages/three-mmd/src/loaders/MMDLoader.js
+++ b/packages/three-mmd/src/loaders/MMDLoader.js
@@ -1451,7 +1451,7 @@ class MaterialBuilder {
 
 //
 
-class MMDToonMaterial extends ShaderMaterial {
+export class MMDToonMaterial extends ShaderMaterial {
   constructor(parameters) {
     super()
 


### PR DESCRIPTION
<img width="1692" height="930" alt="image" src="https://github.com/user-attachments/assets/0d35bb2f-b42f-40d6-8d68-e006568c4d9d" />

With `4.28` of intensity of Directional Light, we can achieve similar results:

<img width="1692" height="930" alt="image" src="https://github.com/user-attachments/assets/e24b792b-9c65-45a7-8a82-469266af009e" />

As for the `2.8` value, it's better for most of the later made or existing models but not good for this:

<img width="1692" height="930" alt="image" src="https://github.com/user-attachments/assets/1192beb7-8b4e-477a-a564-a6b43409fdd3" />

Perhaps, I can find a better way to calculate this by relative references (such as skin brightness, or material basic lighting)

## Additional

Huge thank to following authors shared the code:

- https://github.com/f-a24/three-sandbox/blob/master/src/appendix-B/3.ts
- https://github.com/binzume/aframe-vrm/blob/master/src/utils/vmd.ts
- https://github.com/whstudy/genshin3d/blob/0ea532d03eab656d2da5c15c301b861a80385bfc/src/App.vue#L188-L201
- https://github.com/minimo/tm.mmd.js/blob/f957195a25f42d40f5a5548125fda3b91ede79f4/libs/tm.hybrid.js#L1172