### PR TITLE
fix(three-mmd-b): z flip

### DIFF
--- a/packages/three-mmd-b/src/utils/build-bones.ts
+++ b/packages/three-mmd-b/src/utils/build-bones.ts
@@ -17,7 +17,7 @@ export const buildBones = (pmx: PmxObject, mesh: SkinnedMesh): Bone[] => {
     }
     // Flip Z axis
     pos[2] = -pos[2]
-    
+
     bone.position.fromArray(pos)
     return bone
   })

--- a/packages/three-mmd-b/src/utils/build-geometry.ts
+++ b/packages/three-mmd-b/src/utils/build-geometry.ts
@@ -12,7 +12,7 @@ export const buildGeometry = (pmx: PmxObject): BufferGeometry => {
   const skinIndices = new Uint16Array(vertexCount * 4)
   const skinWeights = new Float32Array(vertexCount * 4)
 
-  pmx.vertices.forEach((v, i) => { 
+  pmx.vertices.forEach((v, i) => {
     // Need to fix the chirality of the model
     // Flip Z axis
     const position = [v.position[0], v.position[1], -v.position[2]]
@@ -57,7 +57,7 @@ export const buildGeometry = (pmx: PmxObject): BufferGeometry => {
   geometry.setAttribute('skinWeight', new BufferAttribute(skinWeights, 4))
 
   // Need to flip the face winding order
-   const indices = Array.from(pmx.indices)
+  const indices = Array.from(pmx.indices)
   for (let i = 0; i < indices.length; i += 3) {
     const tmp = indices[i + 1]
     indices[i + 1] = indices[i + 2]


### PR DESCRIPTION
## Root cause
The problem is that PMX's default Z direction = default negative Z in `three.js`. Therefore, the model was mirrored by the X-Y plane.

## Resolution
- `build-geometry.ts`: positions, normals, face winding order and morph targets are flipped.
- `build-bones.ts`: Z-coordinate flip for each bone.
- **TODO: Given the fact that the animation loading is incomplete so far, need to remember to apply the same Z-flip to the animation trace coordinates.**

## Before vs After

Before: 👎 
<img width="1280" height="647" alt="image" src="https://github.com/user-attachments/assets/31f75978-59c3-493e-bce0-55a2629fc70f" />

After: 👍 
<img width="1728" height="1179" alt="3acaa970269385dce4fbcd6c23861d6a" src="https://github.com/user-attachments/assets/9a6f5a8a-7950-485b-82d0-edf11d394a68" />

The bones are also correct:
<img width="1645" height="1202" alt="a15ef6aa46939e80562ecbc21be24305" src="https://github.com/user-attachments/assets/764dbde3-7e37-4daf-82c6-fe2b38ecad6c" />
