### PR TITLE
fix(physics-ammo): decode PMX rigid body & joint rotations as YXZ euler

### DIFF
--- a/packages/three-mmd-physics-ammo/src/resource-manager.ts
+++ b/packages/three-mmd-physics-ammo/src/resource-manager.ts
@@ -331,7 +331,8 @@ export class ResourceManager {
   setBasisFromArray3(t: Ammo.btTransform, a: number[]) {
     const thQ = this.allocThreeQuaternion()
     const thE = this.allocThreeEuler()
-    thE.set(a[0], a[1], a[2])
+    // PMX joint rotations are yaw-pitch-roll = three.js euler order 'YXZ'
+    thE.set(a[0], a[1], a[2], 'YXZ')
     this.setBasisFromThreeQuaternion(t, thQ.setFromEuler(thE))
 
     this.freeThreeEuler(thE)

--- a/packages/three-mmd-physics-ammo/src/rigid-body.ts
+++ b/packages/three-mmd-physics-ammo/src/rigid-body.ts
@@ -64,10 +64,14 @@ export class RigidBody {
         .applyMatrix4(this.mesh.matrixWorld),
     )
     // Quaternion transform
+    // PMX rigid body rotations are yaw-pitch-roll (babylon-mmd
+    // RotationYawPitchRoll), which is three.js euler order 'YXZ' — the
+    // default 'XYZ' builds compound-rotated bodies perpendicular/mirrored
     const shapeQuat = new Quaternion().setFromEuler(new Euler(
       this.params.shapeRotation[0],
       this.params.shapeRotation[1],
       this.params.shapeRotation[2],
+      'YXZ',
     ))
     const meshWorldQuat = this.mesh.getWorldQuaternion(new Quaternion())
     const boneWorldQuat = bone.getWorldQuaternion(new Quaternion())


### PR DESCRIPTION
## Problem

PMX rigid-body and joint rotation triples are yaw-pitch-roll eulers (babylon-mmd `RotationYawPitchRoll` = three.js euler order **`'YXZ'`**), but the physics-ammo package decodes them with the default **`'XYZ'`** order in two places:

1. `RigidBody` — `shapeQuat` built from an inline `new Euler(x, y, z)`
2. `ResourceManager.setBasisFromArray3` — used by `Constraint` for both `btGeneric6DofSpringConstraint` frames

Rotations about a single axis coincide under both orders, so most bodies *look* correct and the bug hides. But every body with a compound rotation is built perpendicular or mirrored — and because the joint frames use the same decode, limits/springs then act around wrong axes. The visible symptom is severe, un-dampable rest jitter and cloth misbehavior on models whose physics use compound rotations (ribbons, bows, angled hair strands).

## Evidence

Measured on セシリア.pmx by comparing each capsule's decoded Y-axis against its bone→child limb direction at rest pose (angle off the limb axis; 0° = correct):

| body | authored rotation (rad) | XYZ | ZYX | **YXZ** |
|---|---|---|---|---|
| 右腕 (upper-arm collider) | (0.905, 1.572, −0.026) | 67.3° | 1.1° | **1.1°** |
| 右ひじ (elbow collider) | (0.909, 1.746, 0.088) | 73.2° | 7.4° | **7.4°** |
| 前髪 (front bang, y≈π) | (0.043, 3.135, −0.428) | small | 52.1° (mirrored) | **3.1°** |

The bang is the discriminator: ZYX and YXZ agree on the arm rotations but diverge at y≈π — only **YXZ** satisfies all bodies. With this fix all capsules align with their limbs (arm colliders visibly follow the arms in `createHelper()` output) and the constant joint fighting disappears.

For reference, three.js' original `MMDPhysics` used `btMatrix3x3.setEulerZYX` on mmd-parser's left-to-right-converted values — a different pipeline; for the data as parsed here, `'YXZ'` is the empirically correct order.

## Solution

Pass `'YXZ'` explicitly at both decode sites. Two-line change; `pnpm build` and `pnpm test` (35/35) pass.

## Repro

Load any PMX whose rigid bodies rotate about ≥2 axes (arm capsules on most models qualify) and render `physics.createHelper()` — before this fix the capsules cross the limbs instead of following them.